### PR TITLE
fix: Package lambda generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,9 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
 
+      - name: Package Lambda Function with Dependencies
+        run: ./package_lambda.sh
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
 

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,12 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+
+package
+
+.terraform/
+terraform.tfstate
+
+tfplan
+
+lambda-deployment-package.zip

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+AWS_EKS_CLUSTER_NAME=hackathon-eks-cluster
+AWS_SQS_NOTIFICATION_ARN=arn:aws:sqs:us-east-1:905417995957:video-status-notification
+
+# Looks at comments using ## on targets and uses them to produce a help output.
+.PHONY: help
+help: ALIGN=22
+help: ## Print this message
+	@echo "Usage: make <command>"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  make \033[1m%-$(ALIGN)s\033[0m - %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+.PHONY: tf-init
+tf-init: ## Initialize Terraform
+	@echo  "🟢 Initializing Terraform..."
+	@cd terraform && terraform init
+
+.PHONY: tf-validate
+tf-validate: ## Validate Terraform configuration
+	@echo  "🟢 Validating Terraform configuration..."
+	@cd terraform && terraform validate
+
+.PHONY: tf-plan
+tf-plan: ## Show Terraform plan and save to file
+	@echo  "🟢 Showing Terraform plan..."
+	@echo "Using AWS_SQS_NOTIFICATION_ARN: $(AWS_SQS_NOTIFICATION_ARN)"
+	@cd terraform && terraform plan -out=tfplan -var "notification_queue_arn=$(AWS_SQS_NOTIFICATION_ARN)"
+
+.PHONY: tf-apply
+tf-apply: ## Apply Terraform from saved plan
+	@echo  "🟢 Applying Terraform..."
+	@echo "Using AWS_SQS_NOTIFICATION_ARN: $(AWS_SQS_NOTIFICATION_ARN)"
+	@cd terraform && terraform apply -input=false -auto-approve tfplan
+
+.PHONY: tf-apply-direct
+tf-apply-direct: ## Apply Terraform directly (without plan file)
+	@echo  "🟢 Applying Terraform directly..."
+	@echo "Using AWS_SQS_NOTIFICATION_ARN: $(AWS_SQS_NOTIFICATION_ARN)"
+	@cd terraform && terraform apply -var "notification_queue_arn=$(AWS_SQS_NOTIFICATION_ARN)" -input=false -auto-approve
+
+.PHONY: tf-destroy
+tf-destroy: ## Destroy Terraform resources
+	@echo  "🔴 Destroying Terraform resources..."
+	@echo "Using AWS_SQS_NOTIFICATION_ARN: $(AWS_SQS_NOTIFICATION_ARN)"
+	@cd terraform && terraform destroy -var "notification_queue_arn=$(AWS_SQS_NOTIFICATION_ARN)" -auto-approve

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -37,9 +37,9 @@ user_service_endpoint = os.environ.get("USER_SERVICE_ENDPOINT")
 
 
 def get_user_email(user_id):
-    url = f"{user_service_endpoint}/api/v1/users/{user_id}"
+    url = f"{user_service_endpoint}/users/{user_id}"
     log.info(f"Getting user email from {url}")
-    response = requests.get(url)
+    response = requests.post(url)
     user_email = None
     if response.status_code == 200:
         user_email = response.json()["email"]

--- a/package_lambda.sh
+++ b/package_lambda.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Package script for AWS Lambda deployment
+
+# Create package directory
+mkdir -p package
+
+# Install dependencies to package directory
+pip3 install -r requirements.txt --target package/
+
+# Copy Lambda function code to package directory
+cp -r lambda/* package/
+
+# Create deployment ZIP file
+cd package
+zip -r ../lambda-deployment-package.zip .
+cd ..
+
+# Verify the package was created
+ls -la lambda-deployment-package.zip
+
+# Move the deployment package to the Terraform directory
+mv lambda-deployment-package.zip terraform/

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.14.1"
+  constraints = ">= 5.0.0"
+  hashes = [
+    "h1:oacWXQzS6BmkN3lcKKxafYOGUQcUOpneJikw8hqLUyA=",
+    "zh:14d0b4b3dffb3368e6257136bbab1f93d419863dd65d99ef80ca2c1dd3c72a1e",
+    "zh:1de3601251f87a0a989c4b3474baa2efcaf491804f8d7afe15421b728bac5dc5",
+    "zh:2cfe42b853a3b4117bdbb73e5715035eac9b8d753d6e653fd5f30a807a36b985",
+    "zh:3dd8a0336face356928faf2396065634739ef2c3ac3dcaa655570df205559fd9",
+    "zh:42712baca386b84e089b1db8b7844038557f4039b32d8702611aa67eadef7d0f",
+    "zh:4ffc698099e4d7ffc6b0490a4e78ad66b041afd54e988b8bf8e229bcdd4b3ead",
+    "zh:52a6a3b01cb34394b0d06b273b27702fb9d795290a02e5824e198315787e8446",
+    "zh:56eae388c48a844401e44811719dc23be84de538468fd12b7265b06acbf4b51d",
+    "zh:614a918fdf27416b2ee2ce1737895b791f59f9deff3b61246c62a992eabfb8eb",
+    "zh:68605e159177b57fdc4a26bb2caff69a7b69593a601145b7ab5a86fd44b28b9f",
+    "zh:771ac00fd5f211052d735ff0e4b9ec67288abd1e22ffea4ed774aec73c7e5687",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a1355841161e5b53dc3078c88aae1972fd4a9c0d30309b18b1951137b96571fa",
+    "zh:a3c8ca40c1fa7ad76d3d4c3c0039b66a93cc96399e757d2caa0b5cdedce9d3e8",
+    "zh:c77e02a72ef9eb0eb65faaf84c33af843520622dbb51ec31d04ca371bd4d4ee8",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,10 +5,6 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0"
     }
-    archive = {
-      source  = "hashicorp/archive"
-      version = ">= 2.3.0"
-    }
   }
 }
 
@@ -34,34 +30,28 @@ data "aws_iam_policy_document" "lambda_sqs_policy_doc" {
 }
 
 resource "aws_iam_policy" "lambda_sqs_policy" {
-  name   = "${var.project}-lambda-sqs-policy-v3"
+  name   = "${var.project}-lambda-sqs-policy-v5"
   policy = data.aws_iam_policy_document.lambda_sqs_policy_doc.json
 }
 
 
-data "archive_file" "lambda_zip" {
-  type        = "zip"
-  source_dir  = "${path.module}/../lambda"
-  output_path = "${path.module}/build/notification_lambda.zip"
-}
-
 resource "aws_lambda_function" "notification" {
-  function_name = "${var.project}-notification-lambda-v3"
+  function_name = "${var.project}-notification-lambda-v5"
   role          = data.aws_iam_role.fiap_lab_role.arn
   handler       = "main.lambda_handler"
   runtime       = "python3.12"
-  filename      = data.archive_file.lambda_zip.output_path
+  filename      = "${path.module}/lambda-deployment-package.zip"
   timeout       = 30
   memory_size   = 256
 
   environment {
     variables = {
-      MAILTRAP_USER          = var.mailtrap_user
-      MAILTRAP_PASS          = var.mailtrap_pass
-      FROM_EMAIL             = var.from_email
-      USER_SERVICE_ENDPOINT  = var.user_service_endpoint
-      MAILTRAP_HOST          = var.mailtrap_host
-      MAILTRAP_PORT          = tostring(var.mailtrap_port)
+      MAILTRAP_USER         = var.mailtrap_user
+      MAILTRAP_PASS         = var.mailtrap_pass
+      FROM_EMAIL            = var.from_email
+      USER_SERVICE_ENDPOINT = var.user_service_endpoint
+      MAILTRAP_HOST         = var.mailtrap_host
+      MAILTRAP_PORT         = tostring(var.mailtrap_port)
     }
   }
 }
@@ -73,8 +63,8 @@ resource "aws_cloudwatch_log_group" "lambda_logs" {
 
 # Event Source Mapping
 resource "aws_lambda_event_source_mapping" "sqs_to_lambda" {
-  event_source_arn                   = var.notification_queue_arn
-  function_name                      = aws_lambda_function.notification.arn
-  batch_size                         = 5
-  enabled                            = true
+  event_source_arn = var.notification_queue_arn
+  function_name    = aws_lambda_function.notification.arn
+  batch_size       = 5
+  enabled          = true
 }

--- a/terraform/terraform.tfstate.backup
+++ b/terraform/terraform.tfstate.backup
@@ -1,0 +1,120 @@
+{
+  "version": 4,
+  "terraform_version": "1.11.3",
+  "serial": 6,
+  "lineage": "1ff127f8-9d07-02e4-1206-cce0c106d2e6",
+  "outputs": {
+    "notification_lambda_name": {
+      "value": "hackathon-notification-lambda-v5",
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "mode": "data",
+      "type": "aws_iam_policy_document",
+      "name": "lambda_sqs_policy_doc",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "1349325158",
+            "json": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"sqs:ReceiveMessage\",\n        \"sqs:GetQueueAttributes\",\n        \"sqs:DeleteMessage\",\n        \"sqs:ChangeMessageVisibility\"\n      ],\n      \"Resource\": \"arn:aws:sqs:us-east-1:905417995957:video-status-notification\"\n    }\n  ]\n}",
+            "minified_json": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"sqs:ReceiveMessage\",\"sqs:GetQueueAttributes\",\"sqs:DeleteMessage\",\"sqs:ChangeMessageVisibility\"],\"Resource\":\"arn:aws:sqs:us-east-1:905417995957:video-status-notification\"}]}",
+            "override_json": null,
+            "override_policy_documents": null,
+            "policy_id": null,
+            "source_json": null,
+            "source_policy_documents": null,
+            "statement": [
+              {
+                "actions": [
+                  "sqs:ChangeMessageVisibility",
+                  "sqs:DeleteMessage",
+                  "sqs:GetQueueAttributes",
+                  "sqs:ReceiveMessage"
+                ],
+                "condition": [],
+                "effect": "Allow",
+                "not_actions": [],
+                "not_principals": [],
+                "not_resources": [],
+                "principals": [],
+                "resources": [
+                  "arn:aws:sqs:us-east-1:905417995957:video-status-notification"
+                ],
+                "sid": ""
+              }
+            ],
+            "version": "2012-10-17"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "mode": "data",
+      "type": "aws_iam_role",
+      "name": "fiap_lab_role",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:iam::905417995957:role/LabRole",
+            "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"codedeploy.amazonaws.com\",\"secretsmanager.amazonaws.com\",\"sqs.amazonaws.com\",\"redshift.amazonaws.com\",\"ecs.amazonaws.com\",\"elasticbeanstalk.amazonaws.com\",\"codewhisperer.amazonaws.com\",\"eks.amazonaws.com\",\"logs.amazonaws.com\",\"glue.amazonaws.com\",\"athena.amazonaws.com\",\"autoscaling.amazonaws.com\",\"states.amazonaws.com\",\"ec2.amazonaws.com\",\"resource-groups.amazonaws.com\",\"iot.amazonaws.com\",\"cloud9.amazonaws.com\",\"credentials.iot.amazonaws.com\",\"backup.amazonaws.com\",\"ecs-tasks.amazonaws.com\",\"pipes.amazonaws.com\",\"scheduler.amazonaws.com\",\"batch.amazonaws.com\",\"events.amazonaws.com\",\"servicecatalog.amazonaws.com\",\"dynamodb.amazonaws.com\",\"rds.amazonaws.com\",\"kinesisanalytics.amazonaws.com\",\"lambda.amazonaws.com\",\"rekognition.amazonaws.com\",\"forecast.amazonaws.com\",\"iotevents.amazonaws.com\",\"firehose.amazonaws.com\",\"codecommit.amazonaws.com\",\"sagemaker.amazonaws.com\",\"s3.amazonaws.com\",\"apigateway.amazonaws.com\",\"cloudtrail.amazonaws.com\",\"elasticmapreduce.amazonaws.com\",\"elasticloadbalancing.amazonaws.com\",\"ec2.application-autoscaling.amazonaws.com\",\"cognito-idp.amazonaws.com\",\"eks-fargate-pods.amazonaws.com\",\"cloudformation.amazonaws.com\",\"elasticfilesystem.amazonaws.com\",\"deepracer.amazonaws.com\",\"application-autoscaling.amazonaws.com\",\"sns.amazonaws.com\",\"kms.amazonaws.com\",\"ssm.amazonaws.com\",\"kinesis.amazonaws.com\",\"iotanalytics.amazonaws.com\",\"databrew.amazonaws.com\"],\"AWS\":\"arn:aws:iam::905417995957:role/LabRole\"},\"Action\":\"sts:AssumeRole\"}]}",
+            "create_date": "2025-09-27T12:00:22Z",
+            "description": "",
+            "id": "LabRole",
+            "max_session_duration": 3600,
+            "name": "LabRole",
+            "path": "/",
+            "permissions_boundary": "",
+            "role_last_used": [
+              {
+                "last_used_date": "2025-09-28T21:31:36Z",
+                "region": "us-east-1"
+              }
+            ],
+            "tags": {
+              "cloudlab": "c175290a4536275l11579010t1w905417995957"
+            },
+            "unique_id": "AROA5FTY6G22VTJVDZPGR"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_iam_policy",
+      "name": "lambda_sqs_policy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:iam::905417995957:policy/hackathon-lambda-sqs-policy-v5",
+            "attachment_count": 0,
+            "description": "",
+            "id": "arn:aws:iam::905417995957:policy/hackathon-lambda-sqs-policy-v5",
+            "name": "hackathon-lambda-sqs-policy-v5",
+            "name_prefix": "",
+            "path": "/",
+            "policy": "{\"Statement\":[{\"Action\":[\"sqs:ReceiveMessage\",\"sqs:GetQueueAttributes\",\"sqs:DeleteMessage\",\"sqs:ChangeMessageVisibility\"],\"Effect\":\"Allow\",\"Resource\":\"arn:aws:sqs:us-east-1:905417995957:video-status-notification\"}],\"Version\":\"2012-10-17\"}",
+            "policy_id": "ANPA5FTY6G22QIKT334RQ",
+            "tags": null,
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "data.aws_iam_policy_document.lambda_sqs_policy_doc"
+          ]
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}


### PR DESCRIPTION
This pull request introduces a new workflow for packaging and deploying the AWS Lambda function, updates the Terraform configuration to use the new deployment package, and adds Makefile targets for managing Terraform operations. It also modifies the Lambda code to change how user emails are retrieved. The most important changes are grouped below.

**Lambda Packaging & Deployment Workflow**

* Added a new script, `package_lambda.sh`, to automate packaging the Lambda function with its dependencies into a ZIP file for deployment. This script is now called in the GitHub Actions workflow before Terraform setup (`.github/workflows/deploy.yml`, `package_lambda.sh`). [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R47-R49) [[2]](diffhunk://#diff-2ff2f53bcc192ce676056fb0e769ef75ec7a777a6305f1dcc75af6025415e14fR1-R23)

**Terraform Infrastructure Updates**

* Updated the Lambda function resource in `terraform/main.tf` to use the ZIP package created by the new packaging workflow, removed the `archive_file` data source, and incremented the version suffix for IAM policy and Lambda function names.
* Removed the `archive` provider from the Terraform configuration since packaging is now handled externally.
* Added a lock file for Terraform providers to ensure consistent dependency management.
* Added a backup Terraform state file for reference and recovery.

**Developer Experience Improvements**

* Added several Makefile targets (`tf-init`, `tf-validate`, `tf-plan`, `tf-apply`, `tf-apply-direct`, `tf-destroy`) to streamline Terraform operations and included a help target for command discovery.

**Lambda Code Update**

* Changed the request method and endpoint in `lambda/main.py:get_user_email` from a GET to a POST and updated the URL path, which may affect how user data is retrieved from the user service.